### PR TITLE
Change use of master branch to main branch in the conda-package.yml

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -3,7 +3,7 @@ name: Conda package
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 
 permissions: read-all
@@ -47,7 +47,7 @@ jobs:
 
   upload_linux:
     needs: build_and_test_linux
-    if: ${{github.ref == 'refs/heads/master' || (startsWith(github.ref, 'refs/heads/release') == true) || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
+    if: ${{github.ref == 'refs/heads/main' || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
     runs-on: ubuntu-latest
     steps:
       - name: Download conda artifact


### PR DESCRIPTION
Change triggers from using 'master' to using 'main' to enable workflow to trigger after merges of PR
