### PR TITLE
fix: typos, code cleanup, noarch incorrectness

### DIFF
--- a/.github/workflows/conda-package.yml
+++ b/.github/workflows/conda-package.yml
@@ -44,27 +44,3 @@ jobs:
         with:
           name: ${{ env.PACKAGE_NAME }} ${{ runner.os }}
           path: /usr/share/miniconda/conda-bld/noarch/${{ env.PACKAGE_NAME }}-*.conda
-
-  upload_linux:
-    needs: build_and_test_linux
-    if: ${{github.ref == 'refs/heads/main' || github.event_name == 'push' && contains(github.ref, 'refs/tags/')}}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download conda artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: ${{ env.PACKAGE_NAME }} ${{ runner.os }}
-
-      - name: Install anaconda-client
-        run: conda install anaconda-client -c conda-forge --override-channels
-      - name: Add conda to system path
-        run: echo $CONDA/bin >> $GITHUB_PATH
-      - name: Package version
-        run: echo "PACKAGE_VERSION=$(basename ${{ env.PACKAGE_NAME }}-*.conda | sed 's/^${{ env.PACKAGE_NAME }}-\([^-]*\).*/\1/')" >> $GITHUB_ENV
-
-      - name: Upload
-        env:
-          ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
-        run: |
-          anaconda --token $ANACONDA_TOKEN upload --user dppy --label dev ${PACKAGE_NAME}-*.conda
-

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -16,8 +16,8 @@ requirements:
 test:
   commands:
     - export ICD_FN=${CONDA_PREFIX}/etc/OpenCL/vendors/intel-ocl-gpu.icd
-    - test -h ${ICD_FN}
-    - test -e "$(readlink ${ICD_FN})"
+    - if [ -d /etc/OpenCL/vendors ]; then test -h "${ICD_FN}"; fi
+    - if [ -L "${ICD_FN}" ]; then test -e "$(readlink "${ICD_FN}")"; fi
 
 about:
   home: https://github.com/IntelPython/{{ name|lower }}-feedstock

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -6,9 +6,8 @@ package:
   version: {{ version }}
 
 build:
-  noarch: generic
-  number: 2
-  skip: True  # [not linux]
+  number: 3
+  skip: true  # [not linux]
 
 requirements:
   run:
@@ -18,6 +17,7 @@ test:
   commands:
     - export ICD_FN=${CONDA_PREFIX}/etc/OpenCL/vendors/intel-ocl-gpu.icd
     - test -h ${ICD_FN}
+    - test -e "$(readlink ${ICD_FN})"
 
 about:
   home: https://github.com/IntelPython/{{ name|lower }}-feedstock
@@ -45,3 +45,4 @@ about:
 extra:
   recipe-maintainers:
     - ndgrigorian
+    - jharlow-intel

--- a/conda-recipe/post-link.sh
+++ b/conda-recipe/post-link.sh
@@ -18,20 +18,23 @@ systemwide_vendors=/etc/OpenCL/vendors
 env_vendors=${PREFIX}/etc/OpenCL/vendors
 env_icd_fn=$env_vendors/intel-ocl-gpu.icd
 
-if [[ -d $systemwide_vendors ]]
+mkdir -p "$env_vendors"
+
+if [[ -d "$systemwide_vendors" ]]
 then
-    systemwide_icd_fn=$(grep -rl "libigdrcl" ${systemwide_vendors})
-    if [[ -f $systemwide_icd_fn ]]
+    systemwide_icd_fn=$(grep -rl "libigdrcl" "${systemwide_vendors}" | head -n1)
+    if [[ -f "$systemwide_icd_fn" ]]
     then
-        ln -s $systemwide_icd_fn $env_icd_fn
-        echo "Symbolic link was successfully created. OpenCL GPU device should be discoverable by OpenCL loader.\n" >> ${PREFIX}/.messages.txt
+        ln -s "$systemwide_icd_fn" "$env_icd_fn" || true
+        echo "Symbolic link was successfully created. OpenCL GPU device should be discoverable by OpenCL loader.\n" >> "${PREFIX}/.messages.txt"
     else
-        echo "No ICD file for Intel(R) GPU device was found in '${systemwise_vendors}'.\n" >> ${PREFIX}/.messages.txt
-        echo "Creating default symbolic link.\n" >> ${PREFIX}/.messages.txt
-        ln -s ${systemwide_vendors}/intel.icd $env_icd_fn
+        echo "No ICD file for Intel(R) GPU device was found in '${systemwide_vendors}'.\n" >> "${PREFIX}/.messages.txt"
+        if [[ -e "${systemwide_vendors}/intel.icd" ]]
+        then
+            echo "Creating default symbolic link.\n" >> "${PREFIX}/.messages.txt"
+            ln -s "${systemwide_vendors}/intel.icd" "$env_icd_fn" || true
+        fi
     fi
 else
-    echo "Folder '${systemwide_vendors}' does not exist. \n" >> $PREFIX/.messages.txt
-    echo "Creating default symbolic link. \n" >> ${PREFIX}/.messages.txt
-    ln -s ${systemwide_vendors}/intel.icd $env_icd_fn
+    echo "Folder '${systemwide_vendors}' does not exist. \n" >> "${PREFIX}/.messages.txt"
 fi

--- a/conda-recipe/pre-unlink.sh
+++ b/conda-recipe/pre-unlink.sh
@@ -14,9 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-local_vendors=$PREFIX/etc/OpenCL/vendors
-icd_fn=$local_vendors/intel-ocl-gpu.icd
+icd_fn="${PREFIX}"/etc/OpenCL/vendors/intel-ocl-gpu.icd
 
-if [[ -L $icd_fn ]]; then
-    rm $icd_fn
+if [[ -L "$icd_fn" ]]; then
+	rm "$icd_fn" || true
 fi


### PR DESCRIPTION
We had a `systemwise` typo for one of the fallback commands, that's fixed now.

Also removed noarch implementation - this package will no longer be installable on windows starting with this latest build number. Not sure why it ever was to be honest.

Mild change to post-link fallback behavior. I found it weird to say "folder does not exist" - and then use that path to create a symlink. Sounds like it would be a dangling link to me, unless that was somehow the intended behavior. The scripts probably could have used way more comments in them. 

Because we no longer create a dangling link, I had to change the tests, too. Saw it happen immediately with the github actions - the directory didn't exist but we were creating the dangling link and then testing for it. Seemed strange

Lastly, removed upload workflow, we're moving it to conda-forge soon anyways